### PR TITLE
Fix helper integration for MMM-ChatGPT module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+speech_*.mp3
+__pycache__/

--- a/Chat.py
+++ b/Chat.py
@@ -105,7 +105,6 @@ def process_audio(user_message):
     )
     assistant_message = response.choices[0].message.content
     conversation_history.append({"role": "assistant", "content": assistant_message})
-    print(assistant_message)
     speech_response = client.audio.speech.create(
         model="tts-1",
         voice="nova",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # MMM-ChatGPT
-Chatgpt Magic mirror module
-
-
-NOT WORKING YET 2024  WIP 2024-06-17
+ChatGPT Magic Mirror module
  
 The "MMM-ChatGPT" powered by GPT-4o module listens for a trigger word that the user sets, such as "elsa". When it hears the trigger word, it starts listening for the user's question. Once the user asks a question, the module sends the question to the [chatgpt](https://www.npmjs.com/package/chatgpt#cli) and receives a response. It then displays the user's question and the API's response on the Magic Mirror in a bright, medium-sized text. The module also generates an audio response from the API's response text and plays it through the Magic Mirror's speakers.
 
@@ -22,11 +19,11 @@ git clone https://github.com/PierreGode/MMM-ChatGPT.git
 ```
 cd MMM-ChatGPT/
 ```
-Install the necessary dependencies for the module by running the following commands in the terminal within the MMM-ChatGPT folde
+Install the necessary dependencies for the module by running the following commands in the terminal within the MMM-ChatGPT folder
 
 ```
-pip3 install openai googletrans==4.0.0-rc1 gtts SpeechRecognition
-sudo sudo apt-get install portaudio19-dev
+npm install
+pip3 install -r requirements.txt
 ```
 In your Magic Mirror's config.js file, add the following configuration object for the "MMM-ChatGTP" module:
 


### PR DESCRIPTION
## Summary
- invoke Chat.py from the Node helper using spawn and pass the API key
- simplify Chat.py output to return only the response and audio path
- add .gitignore and update README instructions

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check MMM-ChatGPT.js node_helper.js`
- `python -m py_compile Chat.py utils.py`
- `pip install -r requirements.txt` *(fails: PyAudio wheel build error)*

------
https://chatgpt.com/codex/tasks/task_e_68b741c423ec8324b271f21b1edaed0f